### PR TITLE
Fixed file locator to search in all themes if no active theme set

### DIFF
--- a/ActiveTheme.php
+++ b/ActiveTheme.php
@@ -77,7 +77,7 @@ class ActiveTheme
 
     public function setName($name)
     {
-        if (!in_array($name, $this->themes)) {
+        if (!in_array($name, $this->themes) && $name !== null) {
             throw new \InvalidArgumentException(sprintf(
                 'The active theme "%s" must be in the themes list (%s)',
                 $name, implode(',', $this->themes)

--- a/CacheWarmer/TemplatePathsCacheWarmer.php
+++ b/CacheWarmer/TemplatePathsCacheWarmer.php
@@ -51,12 +51,14 @@ class TemplatePathsCacheWarmer extends BaseTemplatePathsCacheWarmer
         $allTemplates = $this->finder->findAllTemplates();
 
         $templates = array();
+        $name = $this->activeTheme->getName();
         foreach ($this->activeTheme->getThemes() as $theme) {
             $this->activeTheme->setName($theme);
             foreach ($allTemplates as $template) {
                 $templates[$template->getLogicalName().'|'.$theme] = $locator->locate($template->getPath());
             }
         }
+        $this->activeTheme->setName($name);
 
         $this->writeCacheFile($cacheDir.'/templates.php', sprintf('<?php return %s;', var_export($templates, true)));
     }

--- a/Locator/FileLocator.php
+++ b/Locator/FileLocator.php
@@ -130,6 +130,23 @@ class FileLocator extends BaseFileLocator
         // update the paths if the theme changed since the last lookup
         $theme = $this->activeTheme->getName();
 
+        if ($theme !== null) {
+            return $this->locateInTheme($name, $theme, $dir, $first);
+        } else {
+            foreach ($this->activeTheme->getThemes() as $theme) {
+                try {
+                    return $this->locateInTheme($name, $theme, $dir, $first);
+                } catch (\InvalidArgumentException $ex) {
+                    // ignore
+                }
+            }
+        }
+
+        throw new \InvalidArgumentException(sprintf('Unable to find file "%s".', $name));
+    }
+
+    private function locateInTheme($name, $theme, $dir = null, $first = null)
+    {
         if ($this->lastTheme !== $theme) {
             $this->setCurrentTheme($theme, $this->activeTheme->getDeviceType());
         }


### PR DESCRIPTION
If no theme was set no template found.

I have added the search in all themes if current theme is null, therefor assetic will browse all themes for assetics.

In the Sulu-Standard could the __active_theme flag removed__.